### PR TITLE
fix: support short commit shas for sparse checkouts

### DIFF
--- a/get_git.go
+++ b/get_git.go
@@ -244,8 +244,20 @@ func (g *GitGetter) clone(ctx context.Context, dst, sshKeyFile string, u *url.UR
 			return err
 		}
 
-		if isCommitID {
+		// If the commit is a long commit sha then we can fetch it
+		if isCommitID && len(ref) == 40 {
 			cmd = exec.CommandContext(ctx, "git", "fetch", "origin", ref, "--depth", "1")
+			cmd.Dir = dst
+			err = getRunCommand(cmd)
+			if err != nil {
+				return err
+			}
+		}
+
+		// If the commit is a short commit sha then we will need to fetch the full history to find the commit
+		// since we can't fetch a commit by short sha
+		if isCommitID && len(ref) < 40 {
+			cmd = exec.CommandContext(ctx, "git", "fetch", "--unshallow", "--filter=blob:none")
 			cmd.Dir = dst
 			err = getRunCommand(cmd)
 			if err != nil {


### PR DESCRIPTION
For short commit SHAs we need to fetch more history to be able to checkout the short commit sha since we can't fetch the reference for it directly.

The other alternative would be using the GitHub API to find the long commit SHA, but this would probably be more complicated as we'd have to do it before invoking go-getter or pass authentication context all the way through.