### PR TITLE
fix(get): ensure getRunCommand does not clobber ExitError's msg

### DIFF
--- a/get.go
+++ b/get.go
@@ -20,7 +20,6 @@ import (
 	"net/url"
 	"os/exec"
 	"regexp"
-	"syscall"
 
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 )
@@ -130,13 +129,11 @@ func getRunCommand(cmd *exec.Cmd) error {
 	}
 	if exiterr, ok := err.(*exec.ExitError); ok {
 		// The program has exited with an exit code != 0
-		if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
-			return fmt.Errorf(
-				"%s exited with %d: %s",
-				cmd.Path,
-				status.ExitStatus(),
-				buf.String())
-		}
+		return fmt.Errorf(
+			"%s exited with %s: %s",
+			cmd.Path,
+			exiterr.ProcessState.String(),
+			buf.String())
 	}
 
 	return fmt.Errorf("error running %s: %s", cmd.Path, buf.String())


### PR DESCRIPTION
Basically,

go-getter is masking the actual problem with incorrect handling of
program exit codes:

1. They messed up err handling in get.go#L131-L140 [1]
2. They eventually get around to calling syscall.WaitStatus.ExitStatus [2]

Which returns -1 if the WaitStatus was something other than exited

So we revert to using the stdlib ProcessState.String() representation
of this error.

[1]: https://github.com/hashicorp/go-getter/blob/v1.7.8/get.go#L131-L140
[2]: https://cs.opensource.google/go/go/+/refs/tags/go1.24.4:src/syscall/syscall_linux.go;l=483-488

---

Internal-Id: `ENG-119`
