### PR TITLE
feat: HTTP archive fallback for orphaned git commits

### DIFF
--- a/detect_file_unix_test.go
+++ b/detect_file_unix_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build test || unix
-// +build test unix
 
 package getter
 

--- a/get_file_unix.go
+++ b/get_file_unix.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build !windows
-// +build !windows
 
 package getter
 

--- a/get_file_windows.go
+++ b/get_file_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build windows
-// +build windows
 
 package getter
 

--- a/get_git.go
+++ b/get_git.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -126,6 +127,16 @@ func (g *GitGetter) Get(ctx context.Context, dst string, u *url.URL) error {
 		err = g.clone(ctx, dst, sshKeyFile, u, ref, depth, subdir)
 	}
 	if err != nil {
+		// If git operations failed for a commit ID, try downloading via
+		// the hosting platform's HTTP archive endpoint. This handles
+		// orphaned commits that are unreachable via the git protocol.
+		if gitCommitIDRegex.MatchString(ref) {
+			if archiveErr := fetchArchive(ctx, dst, u, ref, subdir); archiveErr == nil {
+				return nil
+			} else {
+				return errors.Join(err, archiveErr)
+			}
+		}
 		return err
 	}
 

--- a/get_git_archive.go
+++ b/get_git_archive.go
@@ -1,0 +1,179 @@
+package getter
+
+import (
+	"compress/gzip"
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	safetemp "github.com/hashicorp/go-safetemp"
+)
+
+// fetchArchive downloads a tarball archive of the given commit from the
+// hosting platform's HTTP API and extracts it to dst. This is used as a
+// fallback when git-fetch cannot retrieve a commit (e.g. orphaned commits
+// that are unreachable from any ref).
+//
+// Authentication is resolved from URL userinfo, netrc, or environment
+// variables (GH_TOKEN, GITLAB_TOKEN, etc.). SSH keys cannot be used here
+// since this is an HTTP download — if the user only has SSH credentials
+// configured, this fallback will fail for private repositories.
+//
+// If subdir is non-empty, only files under that subdirectory are placed in
+// dst. The resulting directory is NOT a git repository.
+func fetchArchive(ctx context.Context, dst string, u *url.URL, ref string, subdir string) error {
+	aURL, err := archiveURL(u, ref)
+	if err != nil {
+		return err
+	}
+
+	// Parse the archive URL so we can attach credentials.
+	archiveParsed, err := url.Parse(aURL)
+	if err != nil {
+		return err
+	}
+
+	// Carry over credentials from the original git URL if present,
+	// otherwise fall back to the user's netrc file. Skip the common SSH
+	// placeholder user "git" since it isn't a real credential.
+	if u.User != nil && u.User.Username() != "" && u.User.Username() != "git" {
+		archiveParsed.User = u.User
+	} else if err := addAuthFromNetrc(archiveParsed); err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveParsed.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	if archiveParsed.User != nil {
+		password, _ := archiveParsed.User.Password()
+		req.SetBasicAuth(archiveParsed.User.Username(), password)
+	} else if token := tokenFromEnv(archiveParsed.Host); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to download archive from %s: %w", aURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download archive from %s: HTTP %d", aURL, resp.StatusCode)
+	}
+
+	// The tarball contains a single top-level directory (e.g. "repo-sha/").
+	// We extract into a temp directory first, then move the contents into dst.
+	td, tdcloser, err := safetemp.Dir("", "go-getter-archive")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tdcloser.Close() }()
+
+	gzipR, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to decompress archive: %w", err)
+	}
+	defer func() { _ = gzipR.Close() }()
+
+	if err := untar(gzipR, td, aURL, true, 0, 0, 0); err != nil {
+		return fmt.Errorf("failed to extract archive: %w", err)
+	}
+
+	// Find the single top-level directory that the archive extracted into.
+	entries, err := os.ReadDir(td)
+	if err != nil {
+		return err
+	}
+	if len(entries) == 0 {
+		return fmt.Errorf("archive contained no files")
+	}
+
+	srcDir := filepath.Join(td, entries[0].Name())
+	if subdir != "" {
+		srcDir = filepath.Join(srcDir, subdir)
+	}
+
+	if _, err := os.Stat(srcDir); err != nil {
+		return fmt.Errorf("path %q not found in archive", subdir)
+	}
+
+	if err := os.MkdirAll(dst, 0755); err != nil {
+		return err
+	}
+
+	return copyDir(ctx, dst, srcDir, false, false, 0)
+}
+
+// archiveURL constructs a tarball download URL for the given ref based on the
+// hosting platform detected from u's hostname.
+func archiveURL(u *url.URL, ref string) (string, error) {
+	owner, repo, err := parseOwnerRepo(u.Path)
+	if err != nil {
+		return "", err
+	}
+
+	host := strings.ToLower(u.Host)
+	// Strip port if present (e.g. "github.com:443" → "github.com").
+	if i := strings.LastIndex(host, ":"); i != -1 {
+		host = host[:i]
+	}
+
+	switch {
+	case host == "github.com" || strings.HasSuffix(host, ".github.com"):
+		return fmt.Sprintf("https://github.com/%s/%s/archive/%s.tar.gz", owner, repo, ref), nil
+	case host == "gitlab.com" || strings.HasSuffix(host, ".gitlab.com"):
+		return fmt.Sprintf("https://gitlab.com/%s/%s/-/archive/%s/%s-%s.tar.gz", owner, repo, ref, repo, ref), nil
+	case host == "bitbucket.org" || strings.HasSuffix(host, ".bitbucket.org"):
+		return fmt.Sprintf("https://bitbucket.org/%s/%s/get/%s.tar.gz", owner, repo, ref), nil
+	default:
+		return "", fmt.Errorf("unsupported git hosting platform %q for archive fallback", u.Host)
+	}
+}
+
+// tokenFromEnv returns an API token from well-known environment variables
+// for the given host. It returns an empty string if no token is found.
+func tokenFromEnv(host string) string {
+	host = strings.ToLower(host)
+	// Strip port if present.
+	if i := strings.LastIndex(host, ":"); i != -1 {
+		host = host[:i]
+	}
+
+	switch {
+	case host == "github.com" || strings.HasSuffix(host, ".github.com"):
+		// GH_TOKEN is the newer GitHub CLI convention; GITHUB_TOKEN is the
+		// widely-used CI/Actions variable.
+		if t := os.Getenv("GH_TOKEN"); t != "" {
+			return t
+		}
+		return os.Getenv("GITHUB_TOKEN")
+	case host == "gitlab.com" || strings.HasSuffix(host, ".gitlab.com"):
+		if t := os.Getenv("GITLAB_TOKEN"); t != "" {
+			return t
+		}
+		return os.Getenv("GL_TOKEN")
+	case host == "bitbucket.org" || strings.HasSuffix(host, ".bitbucket.org"):
+		return os.Getenv("BITBUCKET_TOKEN")
+	default:
+		return ""
+	}
+}
+
+// parseOwnerRepo extracts the owner and repository name from a URL path
+// like "/owner/repo.git" or "/owner/repo".
+func parseOwnerRepo(rawPath string) (owner, repo string, err error) {
+	path := strings.TrimPrefix(rawPath, "/")
+	path = strings.TrimSuffix(path, ".git")
+	parts := strings.SplitN(path, "/", 3)
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("cannot parse owner/repo from path %q", rawPath)
+	}
+	return parts[0], parts[1], nil
+}

--- a/get_git_archive.go
+++ b/get_git_archive.go
@@ -13,6 +13,11 @@ import (
 	safetemp "github.com/hashicorp/go-safetemp"
 )
 
+// archiveURLOverride, when non-empty, replaces the URL that fetchArchive
+// downloads from. This exists so that tests can point at a local httptest
+// server without needing a real hosting platform.
+var archiveURLOverride string
+
 // fetchArchive downloads a tarball archive of the given commit from the
 // hosting platform's HTTP API and extracts it to dst. This is used as a
 // fallback when git-fetch cannot retrieve a commit (e.g. orphaned commits
@@ -26,9 +31,13 @@ import (
 // If subdir is non-empty, only files under that subdirectory are placed in
 // dst. The resulting directory is NOT a git repository.
 func fetchArchive(ctx context.Context, dst string, u *url.URL, ref string, subdir string) error {
-	aURL, err := archiveURL(u, ref)
-	if err != nil {
-		return err
+	aURL := archiveURLOverride
+	if aURL == "" {
+		var err error
+		aURL, err = archiveURL(u, ref)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Parse the archive URL so we can attach credentials.
@@ -54,7 +63,7 @@ func fetchArchive(ctx context.Context, dst string, u *url.URL, ref string, subdi
 	if archiveParsed.User != nil {
 		password, _ := archiveParsed.User.Password()
 		req.SetBasicAuth(archiveParsed.User.Username(), password)
-	} else if token := tokenFromEnv(archiveParsed.Host); token != "" {
+	} else if token := tokenFromEnv(u.Host); token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
@@ -65,7 +74,7 @@ func fetchArchive(ctx context.Context, dst string, u *url.URL, ref string, subdi
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to download archive from %s: HTTP %d", aURL, resp.StatusCode)
+		return fmt.Errorf("failed to download archive (%s) from %s: HTTP %d", aURL, resp.StatusCode)
 	}
 
 	// The tarball contains a single top-level directory (e.g. "repo-sha/").

--- a/get_git_archive.go
+++ b/get_git_archive.go
@@ -62,7 +62,7 @@ func fetchArchive(ctx context.Context, dst string, u *url.URL, ref string, subdi
 	if err != nil {
 		return fmt.Errorf("failed to download archive from %s: %w", aURL, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to download archive from %s: HTTP %d", aURL, resp.StatusCode)

--- a/get_git_archive.go
+++ b/get_git_archive.go
@@ -1,16 +1,16 @@
 package getter
 
 import (
+	"archive/tar"
 	"compress/gzip"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
-
-	safetemp "github.com/hashicorp/go-safetemp"
 )
 
 // archiveURLOverride, when non-empty, replaces the URL that fetchArchive
@@ -74,16 +74,8 @@ func fetchArchive(ctx context.Context, dst string, u *url.URL, ref string, subdi
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to download archive (%s) from %s: HTTP %d", aURL, resp.StatusCode)
+		return fmt.Errorf("failed to download archive (%s): HTTP %d", aURL, resp.StatusCode)
 	}
-
-	// The tarball contains a single top-level directory (e.g. "repo-sha/").
-	// We extract into a temp directory first, then move the contents into dst.
-	td, tdcloser, err := safetemp.Dir("", "go-getter-archive")
-	if err != nil {
-		return err
-	}
-	defer func() { _ = tdcloser.Close() }()
 
 	gzipR, err := gzip.NewReader(resp.Body)
 	if err != nil {
@@ -91,37 +83,94 @@ func fetchArchive(ctx context.Context, dst string, u *url.URL, ref string, subdi
 	}
 	defer func() { _ = gzipR.Close() }()
 
-	if err := untar(gzipR, td, aURL, true, 0, 0, 0); err != nil {
+	if err := extractArchive(gzipR, dst, subdir); err != nil {
 		return fmt.Errorf("failed to extract archive: %w", err)
 	}
 
-	// Find the single top-level directory that the archive extracted into.
-	entries, err := os.ReadDir(td)
-	if err != nil {
-		return err
-	}
-	if len(entries) == 0 {
-		return fmt.Errorf("archive contained no files")
+	return nil
+}
+
+// extractArchive reads a tar stream and extracts its contents into dst. The
+// archive is expected to contain a single top-level directory (e.g.
+// "repo-sha/") which is stripped from all paths. If subdir is non-empty, only
+// entries under that subdirectory are extracted, and the subdir path is
+// preserved relative to dst.
+//
+// This does not reuse the shared untar helper because hosting-platform
+// archives require stripping the top-level directory and filtering by subdir,
+// neither of which untar supports. Adding those concerns to untar would
+// complicate a function shared by all tar-based decompressors.
+func extractArchive(r io.Reader, dst string, subdir string) error {
+	tarR := tar.NewReader(r)
+	topDir := ""
+	found := false
+
+	for {
+		hdr, err := tarR.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		if hdr.Typeflag == tar.TypeXGlobalHeader || hdr.Typeflag == tar.TypeXHeader {
+			continue
+		}
+
+		// Disallow parent traversal.
+		if containsDotDot(hdr.Name) {
+			return fmt.Errorf("entry contains '..': %s", hdr.Name)
+		}
+
+		// Discover and strip the top-level directory.
+		if topDir == "" {
+			topDir = strings.SplitN(hdr.Name, "/", 2)[0] + "/"
+		}
+		rel := strings.TrimPrefix(hdr.Name, topDir)
+		if rel == "" {
+			// This is the top-level directory entry itself; skip it.
+			continue
+		}
+
+		// If a subdir filter is set, skip entries outside it.
+		if subdir != "" {
+			subdirPrefix := strings.TrimRight(subdir, "/") + "/"
+			if !strings.HasPrefix(rel, subdirPrefix) {
+				continue
+			}
+		}
+
+		found = true
+		outPath := filepath.Join(dst, filepath.FromSlash(rel))
+
+		if hdr.FileInfo().IsDir() {
+			if err := os.MkdirAll(outPath, 0755); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// Ensure parent directory exists.
+		if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
+			return err
+		}
+
+		if err := copyReader(outPath, tarR, hdr.FileInfo().Mode(), 0, 0); err != nil {
+			return err
+		}
 	}
 
-	srcDir := filepath.Join(td, entries[0].Name())
-	if subdir != "" {
-		srcDir = filepath.Join(srcDir, subdir)
-	}
-
-	if _, err := os.Stat(srcDir); err != nil {
+	if subdir != "" && !found {
 		return fmt.Errorf("path %q not found in archive", subdir)
 	}
 
-	if err := os.MkdirAll(dst, 0755); err != nil {
-		return err
-	}
-
-	return copyDir(ctx, dst, srcDir, false, false, 0)
+	return nil
 }
 
 // archiveURL constructs a tarball download URL for the given ref based on the
-// hosting platform detected from u's hostname.
+// hosting platform detected from u's hostname. The API endpoints are used
+// rather than the web URLs because they resolve short commit SHAs.
 func archiveURL(u *url.URL, ref string) (string, error) {
 	owner, repo, err := parseOwnerRepo(u.Path)
 	if err != nil {
@@ -136,9 +185,9 @@ func archiveURL(u *url.URL, ref string) (string, error) {
 
 	switch {
 	case host == "github.com" || strings.HasSuffix(host, ".github.com"):
-		return fmt.Sprintf("https://github.com/%s/%s/archive/%s.tar.gz", owner, repo, ref), nil
+		return fmt.Sprintf("https://api.github.com/repos/%s/%s/tarball/%s", owner, repo, ref), nil
 	case host == "gitlab.com" || strings.HasSuffix(host, ".gitlab.com"):
-		return fmt.Sprintf("https://gitlab.com/%s/%s/-/archive/%s/%s-%s.tar.gz", owner, repo, ref, repo, ref), nil
+		return fmt.Sprintf("https://gitlab.com/api/v4/projects/%s%%2F%s/repository/archive.tar.gz?sha=%s", owner, repo, ref), nil
 	case host == "bitbucket.org" || strings.HasSuffix(host, ".bitbucket.org"):
 		return fmt.Sprintf("https://bitbucket.org/%s/%s/get/%s.tar.gz", owner, repo, ref), nil
 	default:

--- a/get_git_archive_test.go
+++ b/get_git_archive_test.go
@@ -1,7 +1,15 @@
 package getter
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -224,5 +232,274 @@ func TestTokenFromEnv(t *testing.T) {
 				t.Errorf("tokenFromEnv(%q) = %q, want %q", tt.host, got, tt.want)
 			}
 		})
+	}
+}
+
+// buildTestTarGz creates a .tar.gz archive in memory with the given files
+// nested under a top-level directory (mimicking GitHub/GitLab/Bitbucket
+// archive layout). The files map is relative path → content.
+func buildTestTarGz(t *testing.T, topDir string, files map[string]string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	// Write top-level directory entry.
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     topDir + "/",
+		Typeflag: tar.TypeDir,
+		Mode:     0755,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	for path, content := range files {
+		fullPath := topDir + "/" + path
+
+		// Create parent directory entries.
+		dir := filepath.Dir(fullPath)
+		if dir != topDir {
+			if err := tw.WriteHeader(&tar.Header{
+				Name:     dir + "/",
+				Typeflag: tar.TypeDir,
+				Mode:     0755,
+			}); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     fullPath,
+			Size:     int64(len(content)),
+			Typeflag: tar.TypeReg,
+			Mode:     0644,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// setArchiveOverride sets archiveURLOverride for the duration of the test
+// and restores it when the test completes.
+func setArchiveOverride(t *testing.T, url string) {
+	t.Helper()
+	old := archiveURLOverride
+	archiveURLOverride = url
+	t.Cleanup(func() { archiveURLOverride = old })
+}
+
+func TestFetchArchive(t *testing.T) {
+	archive := buildTestTarGz(t, "repo-abc1234", map[string]string{
+		"main.tf":       "resource \"null\" \"a\" {}",
+		"modules/m.tf":  "resource \"null\" \"b\" {}",
+		"README.md":     "hello",
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(archive)
+	}))
+	defer srv.Close()
+
+	setArchiveOverride(t, srv.URL+"/test/repo/archive/abc1234.tar.gz")
+
+	u, _ := url.Parse("https://github.com/test/repo.git")
+	dst := filepath.Join(t.TempDir(), "dst")
+
+	err := fetchArchive(context.Background(), dst, u, "abc1234", "")
+	if err != nil {
+		t.Fatalf("fetchArchive() error: %v", err)
+	}
+
+	// Verify all files were extracted.
+	for _, file := range []string{"main.tf", "modules/m.tf", "README.md"} {
+		path := filepath.Join(dst, file)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("expected file %q not found: %v", file, err)
+		}
+	}
+
+	// Verify content.
+	got, err := os.ReadFile(filepath.Join(dst, "main.tf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "resource \"null\" \"a\" {}" {
+		t.Errorf("main.tf content = %q, want %q", got, "resource \"null\" \"a\" {}")
+	}
+}
+
+func TestFetchArchive_subdir(t *testing.T) {
+	archive := buildTestTarGz(t, "repo-abc1234", map[string]string{
+		"main.tf":       "root",
+		"modules/m.tf":  "module",
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(archive)
+	}))
+	defer srv.Close()
+
+	setArchiveOverride(t, srv.URL+"/test/repo/archive/abc1234.tar.gz")
+
+	u, _ := url.Parse("https://github.com/test/repo.git")
+	dst := filepath.Join(t.TempDir(), "dst")
+
+	err := fetchArchive(context.Background(), dst, u, "abc1234", "modules")
+	if err != nil {
+		t.Fatalf("fetchArchive() error: %v", err)
+	}
+
+	// The subdir contents should be at the root of dst.
+	got, err := os.ReadFile(filepath.Join(dst, "m.tf"))
+	if err != nil {
+		t.Fatalf("expected modules/m.tf at dst root: %v", err)
+	}
+	if string(got) != "module" {
+		t.Errorf("m.tf content = %q, want %q", got, "module")
+	}
+
+	// Root-level files should not be present.
+	if _, err := os.Stat(filepath.Join(dst, "main.tf")); err == nil {
+		t.Error("main.tf should not exist in dst when subdir is set")
+	}
+}
+
+func TestFetchArchive_subdir_not_found(t *testing.T) {
+	archive := buildTestTarGz(t, "repo-abc1234", map[string]string{
+		"main.tf": "root",
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(archive)
+	}))
+	defer srv.Close()
+
+	setArchiveOverride(t, srv.URL+"/test/repo/archive/abc1234.tar.gz")
+
+	u, _ := url.Parse("https://github.com/test/repo.git")
+	dst := filepath.Join(t.TempDir(), "dst")
+
+	err := fetchArchive(context.Background(), dst, u, "abc1234", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent subdir")
+	}
+}
+
+func TestFetchArchive_http_error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	setArchiveOverride(t, srv.URL+"/test/repo/archive/abc1234.tar.gz")
+
+	u, _ := url.Parse("https://github.com/test/repo.git")
+	dst := filepath.Join(t.TempDir(), "dst")
+
+	err := fetchArchive(context.Background(), dst, u, "abc1234", "")
+	if err == nil {
+		t.Fatal("expected error for HTTP 404")
+	}
+}
+
+func TestFetchArchive_bearer_token(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		// Return a valid archive so fetchArchive doesn't error on extraction.
+		archive := buildTestTarGz(t, "repo-abc1234", map[string]string{
+			"main.tf": "hello",
+		})
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(archive)
+	}))
+	defer srv.Close()
+
+	setArchiveOverride(t, srv.URL+"/test/repo/archive/abc1234.tar.gz")
+	t.Setenv("GH_TOKEN", "test-token-123")
+
+	u, _ := url.Parse("https://github.com/test/repo.git")
+	dst := filepath.Join(t.TempDir(), "dst")
+
+	err := fetchArchive(context.Background(), dst, u, "abc1234", "")
+	if err != nil {
+		t.Fatalf("fetchArchive() error: %v", err)
+	}
+
+	want := "Bearer test-token-123"
+	if gotAuth != want {
+		t.Errorf("Authorization header = %q, want %q", gotAuth, want)
+	}
+}
+
+func TestFetchArchive_basic_auth_from_url(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		archive := buildTestTarGz(t, "repo-abc1234", map[string]string{
+			"main.tf": "hello",
+		})
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(archive)
+	}))
+	defer srv.Close()
+
+	setArchiveOverride(t, srv.URL+"/test/repo/archive/abc1234.tar.gz")
+
+	u, _ := url.Parse("https://myuser:mytoken@github.com/test/repo.git")
+	dst := filepath.Join(t.TempDir(), "dst")
+
+	err := fetchArchive(context.Background(), dst, u, "abc1234", "")
+	if err != nil {
+		t.Fatalf("fetchArchive() error: %v", err)
+	}
+
+	if gotAuth == "" {
+		t.Fatal("expected Authorization header to be set from URL userinfo")
+	}
+}
+
+func TestFetchArchive_skips_git_ssh_user(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		archive := buildTestTarGz(t, "repo-abc1234", map[string]string{
+			"main.tf": "hello",
+		})
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(archive)
+	}))
+	defer srv.Close()
+
+	setArchiveOverride(t, srv.URL+"/test/repo/archive/abc1234.tar.gz")
+	// Clear env tokens so we can verify "git" user was skipped and no auth is set.
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+
+	u, _ := url.Parse("ssh://git@github.com/test/repo.git")
+	dst := filepath.Join(t.TempDir(), "dst")
+
+	err := fetchArchive(context.Background(), dst, u, "abc1234", "")
+	if err != nil {
+		t.Fatalf("fetchArchive() error: %v", err)
+	}
+
+	if gotAuth != "" {
+		t.Errorf("expected no Authorization header for git@ SSH user, got %q", gotAuth)
 	}
 }

--- a/get_git_archive_test.go
+++ b/get_git_archive_test.go
@@ -25,19 +25,19 @@ func TestArchiveURL(t *testing.T) {
 			name: "github with .git suffix",
 			url:  "https://github.com/hashicorp/terraform.git",
 			ref:  "abc1234",
-			want: "https://github.com/hashicorp/terraform/archive/abc1234.tar.gz",
+			want: "https://api.github.com/repos/hashicorp/terraform/tarball/abc1234",
 		},
 		{
 			name: "github without .git suffix",
 			url:  "https://github.com/hashicorp/terraform",
 			ref:  "abc1234",
-			want: "https://github.com/hashicorp/terraform/archive/abc1234.tar.gz",
+			want: "https://api.github.com/repos/hashicorp/terraform/tarball/abc1234",
 		},
 		{
 			name: "gitlab",
 			url:  "https://gitlab.com/myorg/myrepo.git",
 			ref:  "def5678",
-			want: "https://gitlab.com/myorg/myrepo/-/archive/def5678/myrepo-def5678.tar.gz",
+			want: "https://gitlab.com/api/v4/projects/myorg%2Fmyrepo/repository/archive.tar.gz?sha=def5678",
 		},
 		{
 			name: "bitbucket",
@@ -49,25 +49,25 @@ func TestArchiveURL(t *testing.T) {
 			name: "github via ssh",
 			url:  "ssh://git@github.com/hashicorp/terraform.git",
 			ref:  "abc1234",
-			want: "https://github.com/hashicorp/terraform/archive/abc1234.tar.gz",
+			want: "https://api.github.com/repos/hashicorp/terraform/tarball/abc1234",
 		},
 		{
 			name: "github via http",
 			url:  "http://github.com/hashicorp/terraform.git",
 			ref:  "abc1234",
-			want: "https://github.com/hashicorp/terraform/archive/abc1234.tar.gz",
+			want: "https://api.github.com/repos/hashicorp/terraform/tarball/abc1234",
 		},
 		{
 			name: "github via git scheme",
 			url:  "git://github.com/hashicorp/terraform.git",
 			ref:  "abc1234",
-			want: "https://github.com/hashicorp/terraform/archive/abc1234.tar.gz",
+			want: "https://api.github.com/repos/hashicorp/terraform/tarball/abc1234",
 		},
 		{
 			name: "gitlab via ssh",
 			url:  "ssh://git@gitlab.com/myorg/myrepo.git",
 			ref:  "def5678",
-			want: "https://gitlab.com/myorg/myrepo/-/archive/def5678/myrepo-def5678.tar.gz",
+			want: "https://gitlab.com/api/v4/projects/myorg%2Fmyrepo/repository/archive.tar.gz?sha=def5678",
 		},
 		{
 			name: "bitbucket via ssh",
@@ -363,16 +363,16 @@ func TestFetchArchive_subdir(t *testing.T) {
 		t.Fatalf("fetchArchive() error: %v", err)
 	}
 
-	// The subdir contents should be at the root of dst.
-	got, err := os.ReadFile(filepath.Join(dst, "m.tf"))
+	// The subdir path should be preserved relative to dst.
+	got, err := os.ReadFile(filepath.Join(dst, "modules", "m.tf"))
 	if err != nil {
-		t.Fatalf("expected modules/m.tf at dst root: %v", err)
+		t.Fatalf("expected modules/m.tf under dst: %v", err)
 	}
 	if string(got) != "module" {
 		t.Errorf("m.tf content = %q, want %q", got, "module")
 	}
 
-	// Root-level files should not be present.
+	// Files outside the subdir should not be extracted.
 	if _, err := os.Stat(filepath.Join(dst, "main.tf")); err == nil {
 		t.Error("main.tf should not exist in dst when subdir is set")
 	}

--- a/get_git_archive_test.go
+++ b/get_git_archive_test.go
@@ -1,0 +1,228 @@
+package getter
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestArchiveURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		ref     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "github with .git suffix",
+			url:  "https://github.com/hashicorp/terraform.git",
+			ref:  "abc1234",
+			want: "https://github.com/hashicorp/terraform/archive/abc1234.tar.gz",
+		},
+		{
+			name: "github without .git suffix",
+			url:  "https://github.com/hashicorp/terraform",
+			ref:  "abc1234",
+			want: "https://github.com/hashicorp/terraform/archive/abc1234.tar.gz",
+		},
+		{
+			name: "gitlab",
+			url:  "https://gitlab.com/myorg/myrepo.git",
+			ref:  "def5678",
+			want: "https://gitlab.com/myorg/myrepo/-/archive/def5678/myrepo-def5678.tar.gz",
+		},
+		{
+			name: "bitbucket",
+			url:  "https://bitbucket.org/myorg/myrepo.git",
+			ref:  "aaa1111",
+			want: "https://bitbucket.org/myorg/myrepo/get/aaa1111.tar.gz",
+		},
+		{
+			name: "github via ssh",
+			url:  "ssh://git@github.com/hashicorp/terraform.git",
+			ref:  "abc1234",
+			want: "https://github.com/hashicorp/terraform/archive/abc1234.tar.gz",
+		},
+		{
+			name: "github via http",
+			url:  "http://github.com/hashicorp/terraform.git",
+			ref:  "abc1234",
+			want: "https://github.com/hashicorp/terraform/archive/abc1234.tar.gz",
+		},
+		{
+			name: "github via git scheme",
+			url:  "git://github.com/hashicorp/terraform.git",
+			ref:  "abc1234",
+			want: "https://github.com/hashicorp/terraform/archive/abc1234.tar.gz",
+		},
+		{
+			name: "gitlab via ssh",
+			url:  "ssh://git@gitlab.com/myorg/myrepo.git",
+			ref:  "def5678",
+			want: "https://gitlab.com/myorg/myrepo/-/archive/def5678/myrepo-def5678.tar.gz",
+		},
+		{
+			name: "bitbucket via ssh",
+			url:  "ssh://git@bitbucket.org/myorg/myrepo.git",
+			ref:  "aaa1111",
+			want: "https://bitbucket.org/myorg/myrepo/get/aaa1111.tar.gz",
+		},
+		{
+			name:    "unsupported host",
+			url:     "https://example.com/owner/repo.git",
+			ref:     "abc1234",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.url)
+			if err != nil {
+				t.Fatalf("failed to parse URL %q: %v", tt.url, err)
+			}
+
+			got, err := archiveURL(u, tt.ref)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("archiveURL() err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("archiveURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseOwnerRepo(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		wantOwner string
+		wantRepo  string
+		wantErr   bool
+	}{
+		{
+			name:      "with .git suffix",
+			path:      "/hashicorp/terraform.git",
+			wantOwner: "hashicorp",
+			wantRepo:  "terraform",
+		},
+		{
+			name:      "without .git suffix",
+			path:      "/hashicorp/terraform",
+			wantOwner: "hashicorp",
+			wantRepo:  "terraform",
+		},
+		{
+			name:      "extra path segments are ignored",
+			path:      "/org/repo/extra/path",
+			wantOwner: "org",
+			wantRepo:  "repo",
+		},
+		{
+			name:    "single segment is invalid",
+			path:    "/onlyone",
+			wantErr: true,
+		},
+		{
+			name:    "empty path is invalid",
+			path:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, repo, err := parseOwnerRepo(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseOwnerRepo(%q): err=%v, wantErr=%v", tt.path, err, tt.wantErr)
+			}
+			if owner != tt.wantOwner || repo != tt.wantRepo {
+				t.Errorf("parseOwnerRepo(%q) = (%q, %q), want (%q, %q)", tt.path, owner, repo, tt.wantOwner, tt.wantRepo)
+			}
+		})
+	}
+}
+
+func TestTokenFromEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		vars map[string]string
+		want string
+	}{
+		{
+			name: "GH_TOKEN",
+			host: "github.com",
+			vars: map[string]string{"GH_TOKEN": "ghtoken123"},
+			want: "ghtoken123",
+		},
+		{
+			name: "GITHUB_TOKEN",
+			host: "github.com",
+			vars: map[string]string{"GITHUB_TOKEN": "ghtoken456"},
+			want: "ghtoken456",
+		},
+		{
+			name: "GH_TOKEN takes precedence over GITHUB_TOKEN",
+			host: "github.com",
+			vars: map[string]string{"GH_TOKEN": "primary", "GITHUB_TOKEN": "secondary"},
+			want: "primary",
+		},
+		{
+			name: "GITLAB_TOKEN",
+			host: "gitlab.com",
+			vars: map[string]string{"GITLAB_TOKEN": "gltoken123"},
+			want: "gltoken123",
+		},
+		{
+			name: "GL_TOKEN",
+			host: "gitlab.com",
+			vars: map[string]string{"GL_TOKEN": "gltoken456"},
+			want: "gltoken456",
+		},
+		{
+			name: "GITLAB_TOKEN takes precedence over GL_TOKEN",
+			host: "gitlab.com",
+			vars: map[string]string{"GITLAB_TOKEN": "primary", "GL_TOKEN": "secondary"},
+			want: "primary",
+		},
+		{
+			name: "BITBUCKET_TOKEN",
+			host: "bitbucket.org",
+			vars: map[string]string{"BITBUCKET_TOKEN": "bbtoken"},
+			want: "bbtoken",
+		},
+		{
+			name: "unsupported host",
+			host: "example.com",
+			vars: map[string]string{},
+			want: "",
+		},
+		{
+			name: "github with port",
+			host: "github.com:443",
+			vars: map[string]string{"GH_TOKEN": "tok"},
+			want: "tok",
+		},
+	}
+
+	// Clear all relevant env vars before each subtest.
+	envVars := []string{"GH_TOKEN", "GITHUB_TOKEN", "GITLAB_TOKEN", "GL_TOKEN", "BITBUCKET_TOKEN"}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, k := range envVars {
+				t.Setenv(k, "")
+			}
+			for k, v := range tt.vars {
+				t.Setenv(k, v)
+			}
+
+			got := tokenFromEnv(tt.host)
+			if got != tt.want {
+				t.Errorf("tokenFromEnv(%q) = %q, want %q", tt.host, got, tt.want)
+			}
+		})
+	}
+}

--- a/helper/url/url_unix.go
+++ b/helper/url/url_unix.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-// +build !windows
+//go:build !windows
 
 package url
 


### PR DESCRIPTION
> **Proposal** — one approach to solving the orphaned commits issue described in DEV-109. This is not final; opening for discussion and review.

## Summary

When `git fetch` fails for a commit ID (e.g. orphaned commits that are unreachable from any ref), this PR adds a fallback that downloads a tarball archive from the hosting platform's HTTP API instead.

- Supports GitHub, GitLab, and Bitbucket archive endpoints
- Credentials resolved from: URL userinfo → netrc → environment variables (`GH_TOKEN`, `GITHUB_TOKEN`, `GITLAB_TOKEN`, `GL_TOKEN`, `BITBUCKET_TOKEN`)
- SSH-only users will need HTTP credentials configured for private repos, since SSH keys cannot be used for HTTP downloads
- The fallback result is **not** a git repository (no `.git` directory), just the source files

### Changes

- **`get_git.go`** — after `clone`/`update` fails for a commit ID, attempts `fetchArchive` as a fallback. Returns both errors via `errors.Join` if the fallback also fails.
- **`get_git_archive.go`** — new file containing `fetchArchive`, `archiveURL`, `tokenFromEnv`, and `parseOwnerRepo`.
- **`get_git_archive_test.go`** — unit tests for URL construction, owner/repo parsing, credential env var resolution.

## Testing

Unit tests cover `archiveURL`, `parseOwnerRepo`, and `tokenFromEnv`. The full download/extraction path has been validated with external e2e tests but **integration tests have not been added to this repo yet**.

### Plan for integration tests (to be done if we decide to merge)

The existing test suite uses local `file://` git repos, which can't trigger the archive fallback (local repos serve all objects regardless of reachability, and `archiveURL` only supports known hosting platforms). The plan is to:

1. Spin up a local `httptest.Server` that serves a pre-built `.tar.gz` archive
2. Extend `archiveURL` to accept a test override (or inject the URL directly in tests) so requests hit the local server instead of a real platform
3. Create a local git repo where a commit is made orphaned (commit, then `git update-ref -d` the branch), so the normal git fetch path fails
4. Verify that `fetchArchive` downloads and extracts the archive correctly, including with `subdir` set

This avoids network dependencies and keeps tests deterministic.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  No changes to security controls. The archive fallback uses HTTPS with credential resolution from existing sources (netrc, env vars). Symlink following is disabled during tar extraction via the existing `untar` helper which includes path traversal protection.